### PR TITLE
Fix control flow test path error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-test:
     name: build & test (${{ matrix.os }} / py${{ matrix.python-version }})
@@ -61,13 +65,13 @@ jobs:
       - name: Test Python API
         run: |
           echo "Testing Python API functionality..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language import Pack
           p = Pack('test', 'Test pack', 82)
           ns = p.namespace('test')
           ns.function('test_func', 'say Hello World')
           print('[+] Python API test passed')
-          "
+          PY
 
       - name: Test MDL Parsing
         run: |
@@ -77,44 +81,44 @@ jobs:
       - name: Test Variable System
         run: |
           echo "Testing variable system..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language.mdl_parser_js import parse_mdl_js
           test_code = 'var num test_var = 0;'
           ast = parse_mdl_js(test_code)
           print('[+] Variable system test passed')
-          "
+          PY
 
       - name: Test Control Flow
         run: |
           echo "Testing control flow..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language.mdl_parser_js import parse_mdl_js
-          test_code = 'if \"$test$ > 0\" { say \"test\"; }'
+          test_code = 'if "$test$ > 0" { say "test"; }'
           ast = parse_mdl_js(test_code)
           print('[+] Control flow test passed')
-          "
+          PY
 
       - name: Test While Loops
         run: |
           echo "Testing while loops..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language.mdl_parser_js import parse_mdl_js
-          test_code = 'while \"$counter$ < 10\" { counter = $counter$ + 1; }'
+          test_code = 'while "$counter$ < 10" { counter = $counter$ + 1; }'
           ast = parse_mdl_js(test_code)
           print('[+] While loops test passed')
-          "
+          PY
 
       - name: Test Error Handling
         run: |
           echo "Testing error handling..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language.mdl_parser_js import parse_mdl_js
           try:
               parse_mdl_js('invalid syntax {')
               print('[-] Should have failed')
           except:
               print('[+] Error handling test passed')
-          "
+          PY
 
       - name: Test CLI Module Import
         run: |
@@ -124,24 +128,24 @@ jobs:
       - name: Test Basic MDL File
         run: |
           echo "Testing basic MDL file parsing..."
-          python -c "
+          python - <<'PY'
           from minecraft_datapack_language.mdl_parser_js import parse_mdl_js
           test_code = '''
-          pack \"test\" \"Test pack\" 82;
-          namespace \"test\";
+          pack "test" "Test pack" 82;
+          namespace "test";
           var num counter = 0;
-          function \"main\" {
+          function "main" {
               counter = 0;
-              while \"$counter$ < 5\" {
+              while "$counter$ < 5" {
                   counter = $counter$ + 1;
-                  say \"Counter: $counter$\";
+                  say "Counter: $counter$";
               }
           }
-          on_tick \"test:main\";
+          on_tick "test:main";
           '''
           ast = parse_mdl_js(test_code)
           print('[+] Basic MDL file test passed')
-          "
+          PY
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix Windows CI build failure by switching to bash and using heredocs for inline Python commands.

The previous setup caused PowerShell on Windows to misinterpret quotes and special characters within multi-line Python commands, leading to a "Could not find a part of the path" error. Switching the default shell to bash and using heredocs ensures the Python code is passed verbatim, resolving the parsing issue. String literals within the Python `test_code` were also unescaped to reflect this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-858db8bd-6e2a-49bc-af63-311f1cd8bb35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-858db8bd-6e2a-49bc-af63-311f1cd8bb35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

