### PR TITLE
Consolidate navigation and add github link

### DIFF
--- a/MDL_AI_SPEC_SHEET.md
+++ b/MDL_AI_SPEC_SHEET.md
@@ -245,3 +245,6 @@ This simplified approach focuses on **MAKING CONTROL STRUCTURES WORK** rather th
 - Downloads page now auto-sources the latest release using `jekyll-github-metadata` with fallbacks to `docs/_data/version.yml`.
 - Added scheduled and release-triggered workflow `update-website-version.yml` to update `docs/_data/version.yml` with the latest GitHub release tag and version.
 - Docs deploy workflow passes `JEKYLL_GITHUB_TOKEN` to enable GitHub release metadata during Jekyll builds.
+-
+- Removed legacy theme header in `docs/_layouts/default.html` to avoid duplicate navigation with the enhanced nav include.
+- Added a GitHub icon link to `docs/_includes/navigation.html` targeting `https://github.com/{{ site.github_username }}/{{ site.github_repo }}`.

--- a/docs/.env
+++ b/docs/.env
@@ -1,0 +1,1 @@
+JEKYLL_ENV=production

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -16,6 +16,13 @@
         {% endif %}
       {% endfor %}
     </ul>
+    <div class="nav-actions">
+      <a href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}" class="nav-icon-link" aria-label="GitHub Repository" target="_blank" rel="noopener noreferrer">
+        <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+        </svg>
+      </a>
+    </div>
     <button class="nav-toggle" aria-label="Toggle navigation menu">
       <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
         <path d="M2 4h16v2H2V4zm0 5h16v2H2V9zm0 5h16v2H2v-2z"/>
@@ -118,6 +125,28 @@
   text-decoration: none;
 }
 
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 1rem;
+}
+
+.nav-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #24292e;
+  text-decoration: none;
+  padding: 0.35rem;
+  border-radius: 6px;
+}
+
+.nav-icon-link:hover {
+  background: #f6f8fa;
+  color: #0366d6;
+}
+
 .nav-toggle {
   display: none;
   background: none;
@@ -210,6 +239,9 @@
   
   .nav-toggle {
     display: block;
+  }
+  .nav-actions {
+    margin-left: 0.5rem;
   }
   
   .breadcrumb {

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,17 +12,6 @@
   <body>
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
-    <header class="page-header" role="banner">
-      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
-      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
-      {% if site.github.is_project_page %}
-        <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-      {% endif %}
-      {% if site.show_downloads %}
-        <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
-        <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>
-      {% endif %}
-    </header>
 
     <!-- Include Enhanced Navigation -->
     {% include navigation.html %}


### PR DESCRIPTION
Remove redundant header to fix duplicate navigation and add a direct GitHub link icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3a156d9-e485-45b2-b691-af734f49ecd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3a156d9-e485-45b2-b691-af734f49ecd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

