### PR TITLE
Add target syntax to function execution

### DIFF
--- a/MDL_AI_SPEC_SHEET.md
+++ b/MDL_AI_SPEC_SHEET.md
@@ -98,6 +98,10 @@ function "helper" {
 
 // Function calls
 function "namespace:helper";
+
+// Selector on function calls (executes as selector)
+// Compiles to: execute as @a run function test:hello
+function "test:hello<@a>";
 ```
 
 ## Compilation Strategy (SIMPLIFIED)

--- a/MDL_LANGUAGE_SPEC.md
+++ b/MDL_LANGUAGE_SPEC.md
@@ -92,6 +92,13 @@ while "$counter$ < 10000" method="schedule" {
 function "namespace:function_name";
 function "helper";
 function "utils:calculator";
+
+// Execute a function as a specific selector using angle-bracket syntax
+// This compiles to: execute as @a run function test:hello
+function "test:hello<@a>";
+// Selector keywords are supported, e.g., <global> becomes
+// @e[type=armor_stand,tag=mdl_server,limit=1]
+function test:maintask<global>;
 ```
 
 ### 7. Built-in Commands

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -251,6 +251,30 @@ class TestBasicVariableSubstitution(unittest.TestCase):
         finally:
             os.unlink(f_path)
 
+    def test_function_call_with_selector(self):
+        """function name<@a>; should compile to execute as @a run function name"""
+        code = '''
+        pack "test" "description" 82;
+        namespace "test";
+        function "main" {
+            function "test:hello<@a>";
+        }
+        '''
+        ast = parse_mdl_js(code)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.mdl', delete=False) as f:
+            f.write(code)
+            f_path = f.name
+        try:
+            pack = _ast_to_pack(ast, [f_path])
+            self.assertIsNotNone(pack)
+            namespace = pack.namespace('test')
+            function = namespace.function('main')
+            self.assertIsNotNone(function)
+            commands = function.commands
+            self.assertIn('execute as @a run function test:hello', commands)
+        finally:
+            os.unlink(f_path)
+
 
 class TestBasicRegistryTypes(unittest.TestCase):
     """Test basic registry type functionality"""


### PR DESCRIPTION
Add inline selector syntax for function calls to simplify `execute as` commands.

This change allows users to specify a target selector directly within a function call (e.g., `function test:something<@a>;`) instead of using verbose raw blocks. The compiler automatically translates this into an `execute as <selector> run function <name>` command, aligning with the existing variable scope syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-d14f0a1c-9067-4a24-808d-0227876539f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d14f0a1c-9067-4a24-808d-0227876539f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

