### PR TITLE
Implement function macro variable substitution with data compounds

### DIFF
--- a/examples/hello_world.mdl
+++ b/examples/hello_world.mdl
@@ -12,12 +12,18 @@ function "main" {
     say Hello, Minecraft!;
     tellraw @a {"text":"Welcome to my datapack!","color":"green"};
     say Global counter: $globalCounter$;
+    // Call greet_player with macro data using compound
+    exec hello_world:greet_player<@s> "{name:Alex,times:3}";
 }
 
 function "greet_player" {
     // Player-specific greeting
     say Welcome, player! You are visitor number $globalCounter$;
+    // Function Macro example: use $(name) and $(times)
+    $ say Hello $(name) x$(times);
 }
 
 on_load "hello_world:main";
 on_tick "hello_world:greet_player<@a>";
+// Demonstrate with-clause call as well
+// exec hello_world:greet_player<@a> with storage my:data player.info

--- a/minecraft_datapack_language/ast_nodes.py
+++ b/minecraft_datapack_language/ast_nodes.py
@@ -74,6 +74,10 @@ class FunctionCall(ASTNode):
     namespace: str
     name: str
     scope: Optional[str]  # Optional scope for the function call
+    # Optional arguments for function macros (Minecraft 1.21+)
+    # Exactly one of compound or with_clause may be set
+    compound: Optional[str] = None  # e.g., {"name":"Alex","count":2}
+    with_clause: Optional[str] = None  # e.g., storage my:bag items[0]
 
 
 @dataclass
@@ -103,6 +107,12 @@ class HookDeclaration(ASTNode):
 @dataclass
 class RawBlock(ASTNode):
     """Raw block of Minecraft commands."""
+    content: str
+
+
+@dataclass
+class MacroLine(ASTNode):
+    """Function macro line starting with $ and containing $(var) placeholders."""
     content: str
 
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -197,7 +197,9 @@ class TestPythonAPIFunctionCalls:
             "say Starting...",
             "exec test:helper1",
             "exec test:helper2<@s>",
-            "exec test:helper1<@a>"
+            "exec test:helper1<@a>",
+            "exec test:helper2<@s> \"{value:5,name:\\"Bob\\"}\"",
+            "exec test:helper2<@s> with storage my:data path.to"
         )
         
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/vscode-extension/syntaxes/mdl.tmLanguage.json
+++ b/vscode-extension/syntaxes/mdl.tmLanguage.json
@@ -166,18 +166,27 @@
     },
     {
       "name": "function.call.mdl",
-      "begin": "\\b(exec)\\s+([a-zA-Z_][a-zA-Z0-9_]*):([a-zA-Z_][a-zA-Z0-9_]*)\\s*(<)",
-      "end": "(>)",
+      "begin": "\\b(exec)\\s+([a-zA-Z_][a-zA-Z0-9_]*)[:]([a-zA-Z_][a-zA-Z0-9_]*)",
+      "end": ";",
       "beginCaptures": {
         "1": { "name": "keyword.control.mdl" },
         "2": { "name": "entity.name.namespace.mdl" },
-        "3": { "name": "entity.name.function.mdl" },
-        "4": { "name": "punctuation.angle.brackets.mdl" }
-      },
-      "endCaptures": {
-        "1": { "name": "punctuation.angle.brackets.mdl" }
+        "3": { "name": "entity.name.function.mdl" }
       },
       "patterns": [
+        {
+          "name": "punctuation.angle.brackets.mdl",
+          "begin": "<",
+          "end": ">"
+        },
+        {
+          "name": "storage.with.keyword.mdl",
+          "match": "\\bwith\\b"
+        },
+        {
+          "name": "string.quoted.double.mdl",
+          "match": "\"([^\"\\]|\\.)*\""
+        },
         {
           "name": "entity.name.selector.mdl",
           "match": "(@p|@r|@a|@e|@s|@initiator|@c|@v|@d|@w)"


### PR DESCRIPTION
Add support for Minecraft 1.21 Function Macros, enabling dynamic function calls with arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f760d8b0-1161-41b6-8c31-4d5fa08f923b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f760d8b0-1161-41b6-8c31-4d5fa08f923b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

